### PR TITLE
Cloud Composer can now run the dbt_build task by calling "dbt build" on the Docker image, running it in Google Kubernetes Engine.

### DIFF
--- a/airflow/dbt_build.py
+++ b/airflow/dbt_build.py
@@ -1,0 +1,44 @@
+from datetime import timedelta
+
+from airflow import DAG
+from airflow.providers.google.cloud.operators.kubernetes_engine import GKEStartPodOperator
+from airflow.utils.dates import days_ago
+
+default_args = {
+    'owner': 'airflow',
+    'depends_on_past': False,
+    'start_date': days_ago(1),
+    'email_on_failure': False,
+    'email_on_retry': False,
+    'retries': 0,
+    'retry_delay': timedelta(minutes=5),
+    'catchup': False
+}
+
+GCP_PROJECT_ID = "henrytxz"
+GCP_LOCATION   = "us-east1"
+CLUSTER_NAME   = "us-east1-demo-f5cd9848-gke"
+DBT_IMAGE      = "us-docker.pkg.dev/henrytxz/data-demo/data-demo-dbt:latest"
+
+with DAG(
+    dag_id='SQL_workload',
+    default_args=default_args,
+    schedule_interval='@hourly',
+    catchup=False
+) as dag:
+
+    dbt_run = GKEStartPodOperator(
+        task_id='dbt_build',
+        project_id=GCP_PROJECT_ID,
+        location=GCP_LOCATION,
+        cluster_name=CLUSTER_NAME,
+        do_xcom_push=False,
+        namespace='default',
+        image=DBT_IMAGE,
+        cmds=["dbt", "build", "--profile", "dev"],
+        # cmds=["dbt", "build", "--profile", "prod"],
+        name='dbt_build',
+        is_delete_operator_pod=True,
+        startup_timeout_seconds=60*5,
+        env_vars={'PATH_GCP_KEYFILE': '/dbt/dbt-user.json'}
+    )

--- a/airflow/refresh_table_schema.py
+++ b/airflow/refresh_table_schema.py
@@ -14,7 +14,7 @@ default_args = {
 	'retry_delay': timedelta(minutes=5),
 }
 
-BUCKET = 'us-east1-demo-e11d66ca-bucket'
+BUCKET = 'us-east1-demo-f5cd9848-bucket'
 
 with DAG(
 		dag_id='create_replace_game_play_activity_table',


### PR DESCRIPTION
### Testing
Provide testing evidence (screenshots, etc.)

The 1st 2 DAG (stands for direct-acyclic-graph, a DAG is a data pipeline in Airflow), the 1st 2 DAG runs failed and I debugged, the last 2 DAG runs both succeeded and were green.
![Airflow DAG SQL_workload](https://user-images.githubusercontent.com/3128529/154995667-21584123-3fb5-4a96-a73b-86dcc9be84be.png)
![Prod table refreshed by dbt and Airflow](https://user-images.githubusercontent.com/3128529/154996141-ffb0b083-dd5b-4656-9a65-645ca7449469.png)

