### PR TITLE
Google Cloud Build needs one to specify where to store Google Cloud build logs

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -25,3 +25,6 @@ steps:
 images:
 - 'us-docker.pkg.dev/henrytxz/data-demo/data-demo-dbt:$SHORT_SHA'
 - 'us-docker.pkg.dev/henrytxz/data-demo/data-demo-dbt:latest'
+
+options:
+  logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
### Testing
Will test in Google Cloud Build.
